### PR TITLE
fix environment variables to match README

### DIFF
--- a/android_kotlin_compose/sample/build.gradle
+++ b/android_kotlin_compose/sample/build.gradle
@@ -13,8 +13,8 @@ android {
         versionCode 1
         versionName "1.0"
 
-        buildConfigField "String", "CITYMAPPER_API_KEY", "\"${project.findProperty("SAMPLE_API_KEY") ?: ""}\""
-        buildConfigField "String", "CITYMAPPER_ENDPOINT_URL", "\"${project.findProperty("SAMPLE_ENDPOINT_URL") ?: ""}\""
+        buildConfigField "String", "CITYMAPPER_API_KEY", "\"${project.findProperty("CITYMAPPER_API_KEY") ?: ""}\""
+        buildConfigField "String", "CITYMAPPER_ENDPOINT_URL", "\"${project.findProperty("CITYMAPPER_ENDPOINT_URL") ?: ""}\""
 
         resValue "string", "google_map_key", "\"${project.findProperty("CITYMAPPER_SAMPLE_GOOGLE_MAP_KEY") ?: ""}\""
 


### PR DESCRIPTION
The README asks for the following in ~/.gradle/gradle.properties:

```
CITYMAPPER_API_KEY=[your API key]
CITYMAPPER_ENDPOINT_URL=[your API endpoint url]
CITYMAPPER_SAMPLE_GOOGLE_MAP_KEY=[your google map key]
```

However the module build.gradle has:

```
  buildConfigField "String", "CITYMAPPER_API_KEY", "\"${project.findProperty("SAMPLE_API_KEY") ?: ""}\""
  buildConfigField "String", "CITYMAPPER_ENDPOINT_URL", "\"${project.findProperty("SAMPLE_ENDPOINT_URL") ?: ""}\""
```

So it is looking for SAMPLE_API_KEY instead of CITYMAPPER_API_KEY.

Modifying these names fixes the demo.